### PR TITLE
Fix pushed byte in OP_10-OP_16

### DIFF
--- a/opcodes/OP_10.md
+++ b/opcodes/OP_10.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 10 onto the stack.  
 :::
 
-The `OP_10` opcode will push `0x5a` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_10` opcode will push `0x0a` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_11.md
+++ b/opcodes/OP_11.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 11 onto the stack.  
 :::
 
-The `OP_11` opcode will push `0x5b` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_11` opcode will push `0x0b` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_12.md
+++ b/opcodes/OP_12.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 12 onto the stack.  
 :::
 
-The `OP_12` opcode will push `0x5c` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_12` opcode will push `0x0c` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_13.md
+++ b/opcodes/OP_13.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 13 onto the stack.  
 :::
 
-The `OP_13` opcode will push `0x5d` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_13` opcode will push `0x0d` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_14.md
+++ b/opcodes/OP_14.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 14 onto the stack.  
 :::
 
-The `OP_14` opcode will push `0x5e` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_14` opcode will push `0x0e` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_15.md
+++ b/opcodes/OP_15.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 15 onto the stack.  
 :::
 
-The `OP_15` opcode will push `0x5f` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_15` opcode will push `0x0f` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_16.md
+++ b/opcodes/OP_16.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 16 onto the stack.  
 :::
 
-The `OP_16` opcode will push `0x60` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The `OP_16` opcode will push `0x10` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1


### PR DESCRIPTION
Opcodes `OP_10`-`OP_16` push the bytes `0x0a`-`0x10`, not `0x5a`-`0x60`.