### PR TITLE
Add minimal push section, improve push opcode pages

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -292,6 +292,7 @@ export default defineConfig({
       "/script/": [
         { text: "Script Success and Failure", link: "/script/script.md" },
         { text: "ASM Representation", link: "/script/asm.md" },
+        { text: "Push Operators", link: "/script/push.md" },
         { text: "Numbers in Script", link: "/script/numbers.md" },
       ]
     },

--- a/opcodes/OP_PUSHBYTES_1.md
+++ b/opcodes/OP_PUSHBYTES_1.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next byte onto the stack. 
 :::
 
-The `OP_PUSHBYTES_1` opcode will push the following byte onto the stack.
+The `OP_PUSHBYTES_1` opcode will push the following byte onto the stack. For the bytes `0x01` to `0x10` it is more efficient (and required by standardness rules) to use opcodes `OP_1` to `OP_16`, and for the byte `0x81` to use `OP_1NEGATE` (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHDATA1.md
+++ b/opcodes/OP_PUSHDATA1.md
@@ -5,23 +5,7 @@
 **Short description:** Read the next byte as `N`. Push the next `N` bytes as an array onto the stack.
 :::
 
-The `OP_PUSHDATA1` opcode will read the byte that follows it and interpret it as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads a single byte and inteprets it as a number, this opcode can push any number of bytes from 1 to 255. Note that for any number of bytes under 76, it is more efficient to use any of the opcodes in the `OP_PUSHBYTES` family. For example pushing 4 bytes to the stack using `OP_PUSHDATA1` would look like this:
-```shell
-# ASM script
-OP_PUSHDATA1 04 ababcdcd
-
-# Raw script
-4c04ababcdcd
-```
-
-When you could save a byte by using `OP_PUSHBYTES_4`:
-```shell
-# ASM script
-OP_PUSHBYTES_4 ababcdcd
-
-# Raw script
-04ababcdcd
-```
+The `OP_PUSHDATA1` opcode will read the byte that follows it and interpret it as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads a single byte and inteprets it as a number, this opcode can push any number of bytes from 0 to 255. Note that for any number of bytes under 76, it is more efficient (and required by standardness rules) to use opcodes in the `OP_PUSHBYTES` family, or more specific opcodes where applicable (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
 `OP_PUSHDATA1` is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA2](./OP_PUSHDATA2.md) and [OP_PUSHDATA4](./OP_PUSHDATA4.md)).
 

--- a/opcodes/OP_PUSHDATA2.md
+++ b/opcodes/OP_PUSHDATA2.md
@@ -5,7 +5,7 @@
 **Short description:** Read the next 2 bytes as `N`. Push the next `N` bytes as an array onto the stack.
 :::
 
-The `OP_PUSHDATA2` opcode will read the 2 bytes that follows it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 2 bytes and inteprets them as a number, this opcode can push any number of bytes from 1 to 65,535. Note that for any number of bytes over 75 and under 255, it is more efficient to use `OP_PUSHDATA1` (saving 1 byte), and for any number of bytes under 76, any of the opcodes in the `OP_PUSHBYTES` family (saving 2 bytes). See the `[OP_PUSHDATA1](./OP_PUSHDATA1.md) page for more of this.
+The `OP_PUSHDATA2` opcode will read the 2 bytes that follow it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 2 bytes and inteprets them as a number, this opcode can push any number of bytes from 0 to 65,535, though consensus rules only allow at most 520 bytes in one push. Note that for any number of bytes between 76 and 255, it is more efficient (and required by standardness rules) to use `OP_PUSHDATA1`, and for any number of bytes under 76, opcodes in the `OP_PUSHBYTES` family, or more specific opcodes where applicable (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
 `OP_PUSHDATA2` is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA4](./OP_PUSHDATA4.md)).
 

--- a/opcodes/OP_PUSHDATA4.md
+++ b/opcodes/OP_PUSHDATA4.md
@@ -5,19 +5,6 @@
 **Short description:** Read the next 4 bytes as `N`. Push the next `N` bytes as an array onto the stack.
 :::
 
-The `OP_PUSHDATA4` opcode will read the 4 bytes that follows it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 4 bytes and inteprets them as a number, this opcode can push any number of bytes from 1 to 4,294,967,295. Note that for any number of bytes under 65,535, it is more efficient to use either of `OP_PUSHDATA2` (saving 2 bytes), `OP_PUSHDATA1` (saving 1 byte), or any of the opcodes in the `OP_PUSHBYTES` family (saving 4 bytes), depending on the exact situation/number of bytes you need to push on the stack. See the `[OP_PUSHDATA1](./OP_PUSHDATA1.md) page for more of this.
+The `OP_PUSHDATA4` opcode will read the 4 bytes that follow it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 4 bytes and inteprets them as a number, this opcode can push any number of bytes from 0 to 4,294,967,295. Since the largest data push allowed by consensus rules is 520 bytes for which it is more efficient (and required by standardness rules) to use `OP_PUSHDATA2`, this opcode is never used in practice (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
 `OP_PUSHDATA4` is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA2](./OP_PUSHDATA2.md)).
-
-## Example
-A good example for this opcode would require a push of a minimum of 65,536 bytes; we're cutting this one for brievity. See the pages for [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA2](./OP_PUSHDATA2.md) for complete examples.
-```shell
-# ASM script pushing 4,000,000 bytes
-OP_PUSHDATA4 003d0900 <4 million bytes>
-
-# Raw script
-4e003d0900<4millionbytes>
-
-# Final stack
-<4millionbytes>
-```

--- a/script/push.md
+++ b/script/push.md
@@ -1,0 +1,15 @@
+# Push Operators
+
+## Minimal push operations
+
+Bitcoin's scripting language has several operators for pushing data onto the stack. When there are multiple options for how to push the same byte array, the commonly used standardness rules require that the smallest possible encoding be used:
+
+* Pushing an empty byte array must use `OP_0`.
+* Pushing a byte between `0x01` and `0x10` must use `OP_1` to `OP_16`.
+* Pushing the byte `0x81` must use `OP_1NEGATE`.
+* Pushing any other byte array up to 75 bytes must use the corresponding `OP_PUSHBYTES` opcode.
+* Pushing 76 to 255 bytes must use `OP_PUSHDATA1`.
+* Pushing 256 to 65535 bytes must use `OP_PUSHDATA2`.
+* Pushing 65536 bytes or more must use `OP_PUSHDATA4`.
+
+Note that the largest push allowed by consensus rules is 520 bytes, which means `OP_PUSHDATA4` is never used in practice.


### PR DESCRIPTION
The push opcode pages never mention that it isn't just more efficient to e.g. use a `OP_PUSHBYTES` opcode for pushing less than 76 bytes but it's actually required by standardness rules. This change should better reflect that.

References:
- [Bitcoin Core's `CheckMinimalPush`](https://github.com/bitcoin/bitcoin/blob/v25.1/src/script/script.cpp#L343)
- [BIP62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) which proposed this as a consensus rule