### PR TITLE
Hyperlink all referenced opcodes

### DIFF
--- a/opcodes/OP_0.md
+++ b/opcodes/OP_0.md
@@ -6,7 +6,7 @@
 **Short Description:** Push an empty byte array onto the stack.  
 :::
 
-The `OP_0` opcode, which corresponds to the byte `0x00`, doesn't push the numeric value `0` onto the stack; rather, it pushes a zero-length byte array.
+The [`OP_0`](./OP_0.md) opcode, which corresponds to the byte `0x00`, doesn't push the numeric value `0` onto the stack; rather, it pushes a zero-length byte array.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_1.md
+++ b/opcodes/OP_1.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 1 onto the stack. 
 :::
 
-The `OP_1` opcode, which corresponds to the byte `0x51`, pushes the number 1 onto the stack. `OP_1`` is a fundamental opcode in Bitcoin Script, enabling a variety of operations and serving as a building block for more complex scripts.
+The [`OP_1`](./OP_1.md) opcode, which corresponds to the byte `0x51`, pushes the number 1 onto the stack. [`OP_1`](./OP_1.md)` is a fundamental opcode in Bitcoin Script, enabling a variety of operations and serving as a building block for more complex scripts.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_10.md
+++ b/opcodes/OP_10.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 10 onto the stack.  
 :::
 
-The `OP_10` opcode will push `0x0a` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_10`](./OP_10.md) opcode will push `0x0a` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_11.md
+++ b/opcodes/OP_11.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 11 onto the stack.  
 :::
 
-The `OP_11` opcode will push `0x0b` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_11`](./OP_11.md) opcode will push `0x0b` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_12.md
+++ b/opcodes/OP_12.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 12 onto the stack.  
 :::
 
-The `OP_12` opcode will push `0x0c` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_12`](./OP_12.md) opcode will push `0x0c` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_13.md
+++ b/opcodes/OP_13.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 13 onto the stack.  
 :::
 
-The `OP_13` opcode will push `0x0d` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_13`](./OP_13.md) opcode will push `0x0d` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_14.md
+++ b/opcodes/OP_14.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 14 onto the stack.  
 :::
 
-The `OP_14` opcode will push `0x0e` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_14`](./OP_14.md) opcode will push `0x0e` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_15.md
+++ b/opcodes/OP_15.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 15 onto the stack.  
 :::
 
-The `OP_15` opcode will push `0x0f` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_15`](./OP_15.md) opcode will push `0x0f` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_16.md
+++ b/opcodes/OP_16.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 16 onto the stack.  
 :::
 
-The `OP_16` opcode will push `0x10` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_16`](./OP_16.md) opcode will push `0x10` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_1NEGATE.md
+++ b/opcodes/OP_1NEGATE.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the number -1 onto the stack.  
 :::
 
-The `OP_1NEGATE` opcode will push `0x81` (representing -1 in the context of script execution) onto the stack. This opcode utilizes the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_1NEGATE`](./OP_1NEGATE.md) opcode will push `0x81` (representing -1 in the context of script execution) onto the stack. This opcode utilizes the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1
@@ -33,4 +33,4 @@ OP_8 OP_1NEGATE OP_ADD
 7
 ```
 
-In the first example, we have a script with two `OP_1NEGATE` opcodes. After execution, we have two -1s on the stack. In the second example, we add another opcode, `OP_ADD`, to the script. The `OP_ADD` opcode will remove the two top items from the stack, add them together, and then push the result back onto the stack. 8 + (-1) results in 7, which is then pushed onto the stack.
+In the first example, we have a script with two [`OP_1NEGATE`](./OP_1NEGATE.md) opcodes. After execution, we have two -1s on the stack. In the second example, we add another opcode, [`OP_ADD`](./OP_ADD.md), to the script. The [`OP_ADD`](./OP_ADD.md) opcode will remove the two top items from the stack, add them together, and then push the result back onto the stack. 8 + (-1) results in 7, which is then pushed onto the stack.

--- a/opcodes/OP_2.md
+++ b/opcodes/OP_2.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 2 onto the stack.  
 :::
 
-The `OP_2` opcode will push `0x02` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_2`](./OP_2.md) opcode will push `0x02` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_2DIV.md
+++ b/opcodes/OP_2DIV.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_2DIV` is a disabled opcode in the Bitcoin scripting system.
+[`OP_2DIV`](./OP_2DIV.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-`OP_2DIV` was initially designed to perform division operations by dividing the top item on the stack by 2.
+[`OP_2DIV`](./OP_2DIV.md) was initially designed to perform division operations by dividing the top item on the stack by 2.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_2DIV` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_2DIV`](./OP_2DIV.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_2DIV` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_2DIV`](./OP_2DIV.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_2DROP.md
+++ b/opcodes/OP_2DROP.md
@@ -5,17 +5,17 @@
 **Short description:** Drop the top two items from the stack.
 :::
 
-`OP_2DROP` is used to discard the top two items from the stack.
+[`OP_2DROP`](./OP_2DROP.md) is used to discard the top two items from the stack.
 
 ### Operation
 1. Pop the top item from the stack.
 2. Pop the next item from the stack.
 
 ### Use Cases
-- **Discarding Temporary Data:** In scripts where temporary values are pushed onto the stack for interim calculations, `OP_2DROP` can be used to remove them once they are no longer needed.
+- **Discarding Temporary Data:** In scripts where temporary values are pushed onto the stack for interim calculations, [`OP_2DROP`](./OP_2DROP.md) can be used to remove them once they are no longer needed.
 
 ### Notes
-- This opcode is part of a family of opcodes ([`OP_DROP`](#), `OP_2DROP`, [`OP_2DUP`](#), [`OP_3DUP`](#), and a few others) designed for stack item management.
+- This opcode is part of a family of opcodes ([`OP_DROP`](#), [`OP_2DROP`](./OP_2DROP.md), [`OP_2DUP`](#), [`OP_3DUP`](#), and a few others) designed for stack item management.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_2MUL.md
+++ b/opcodes/OP_2MUL.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_2MUL` is a disabled opcode in the Bitcoin scripting system.
+[`OP_2MUL`](./OP_2MUL.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-`OP_2MUL` was originally intended for multiplication operations, specifically to multiply the top item on the stack by 2.
+[`OP_2MUL`](./OP_2MUL.md) was originally intended for multiplication operations, specifically to multiply the top item on the stack by 2.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_2MUL` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_2MUL`](./OP_2MUL.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_2MUL` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_2MUL`](./OP_2MUL.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_3.md
+++ b/opcodes/OP_3.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 3 onto the stack.  
 :::
 
-The `OP_3` opcode will push `0x03` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_3`](./OP_3.md) opcode will push `0x03` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_4.md
+++ b/opcodes/OP_4.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 4 onto the stack.  
 :::
 
-The `OP_4` opcode will push `0x04` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_4`](./OP_4.md) opcode will push `0x04` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_5.md
+++ b/opcodes/OP_5.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 5 onto the stack.  
 :::
 
-The `OP_5` opcode will push `0x05` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_5`](./OP_5.md) opcode will push `0x05` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_6.md
+++ b/opcodes/OP_6.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 6 onto the stack.  
 :::
 
-The `OP_6` opcode will push `0x06` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_6`](./OP_6.md) opcode will push `0x06` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_7.md
+++ b/opcodes/OP_7.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 7 onto the stack.  
 :::
 
-The `OP_7` opcode will push `0x07` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_7`](./OP_7.md) opcode will push `0x07` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_8.md
+++ b/opcodes/OP_8.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 8 onto the stack.  
 :::
 
-The `OP_8` opcode will push `0x08` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_8`](./OP_8.md) opcode will push `0x08` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_9.md
+++ b/opcodes/OP_9.md
@@ -6,7 +6,7 @@
 **Short Description:** Push the number 9 onto the stack.  
 :::
 
-The `OP_9` opcode will push `0x09` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
+The [`OP_9`](./OP_9.md) opcode will push `0x09` onto the stack. This opcode uses the [minimally encoded integers format](../script/numbers.md#minimally-encoded-integers).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_ADD.md
+++ b/opcodes/OP_ADD.md
@@ -5,9 +5,9 @@
 **Short Description:** Pop two stack items and push their sum.  
 :::
 
-`OP_ADD` adds two numbers together and returns their sum on the stack.
+[`OP_ADD`](./OP_ADD.md) adds two numbers together and returns their sum on the stack.
 
-The execution of the `OP_ADD` opcode involves three steps:
+The execution of the [`OP_ADD`](./OP_ADD.md) opcode involves three steps:
 1. Pop the top item from the stack.
 2. Pop the next top item from the stack.
 3. Add these two items together, and push the result back onto the stack.

--- a/opcodes/OP_AND.md
+++ b/opcodes/OP_AND.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_AND` is a disabled opcode in the bitcoin scripting system.
+[`OP_AND`](./OP_AND.md) is a disabled opcode in the bitcoin scripting system.
 
 ### Historical Context
-Initially, the `OP_AND` opcode was designed to perform a bitwise AND operation on the top two items on the stack. This means it would take two numbers and return a new number, where each bit in the result is the logical AND of the corresponding bits in the input numbers.
+Initially, the [`OP_AND`](./OP_AND.md) opcode was designed to perform a bitwise AND operation on the top two items on the stack. This means it would take two numbers and return a new number, where each bit in the result is the logical AND of the corresponding bits in the input numbers.
 
-However, as part of a broader effort to reduce potential vulnerabilities and to simplify bitcoin's scripting language, `OP_AND` was disabled early in bitcoin's history along with several other opcodes.
+However, as part of a broader effort to reduce potential vulnerabilities and to simplify bitcoin's scripting language, [`OP_AND`](./OP_AND.md) was disabled early in bitcoin's history along with several other opcodes.
 
 ### Operation
-Because `OP_AND` is disabled, any script that contains it will immediately render the transaction invalid, regardless of other script operations or context.
+Because [`OP_AND`](./OP_AND.md) is disabled, any script that contains it will immediately render the transaction invalid, regardless of other script operations or context.

--- a/opcodes/OP_CAT.md
+++ b/opcodes/OP_CAT.md
@@ -5,7 +5,7 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_CAT` is a disabled opcode in the bitcoin scripting system.
+[`OP_CAT`](./OP_CAT.md) is a disabled opcode in the bitcoin scripting system.
 
 ### Operation
-Because `OP_CAT` is disabled, any script that contains it will cause the transaction to be invalid regardless of context. This opcode was originally intended to concatenate two strings but due to concerns about potential vulnerabilities, it was disabled early in bitcoin's history.
+Because [`OP_CAT`](./OP_CAT.md) is disabled, any script that contains it will cause the transaction to be invalid regardless of context. This opcode was originally intended to concatenate two strings but due to concerns about potential vulnerabilities, it was disabled early in bitcoin's history.

--- a/opcodes/OP_DIV.md
+++ b/opcodes/OP_DIV.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_DIV` is a disabled opcode in the Bitcoin scripting system.
+[`OP_DIV`](./OP_DIV.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-`OP_DIV` was initially intended for division operations, specifically to divide the second-to-top stack item by the top stack item.
+[`OP_DIV`](./OP_DIV.md) was initially intended for division operations, specifically to divide the second-to-top stack item by the top stack item.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_DIV` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_DIV`](./OP_DIV.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_DIV` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_DIV`](./OP_DIV.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_ELSE.md
+++ b/opcodes/OP_ELSE.md
@@ -2,14 +2,14 @@
 :::info
 **Opcode number:** 103  
 **Byte representation:** `0x67`  
-**Short description:** Execute following script if the previous `OP_IF` or `OP_NOTIF` condition was not met.
+**Short description:** Execute following script if the previous [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md) condition was not met.
 :::
 
-`OP_ELSE` is an essential part of conditional structures in Bitcoin scripting. It allows for alternative execution paths depending on conditions evaluated by preceding [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md) opcodes.
+[`OP_ELSE`](./OP_ELSE.md) is an essential part of conditional structures in Bitcoin scripting. It allows for alternative execution paths depending on conditions evaluated by preceding [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md) opcodes.
 
 ### Operation
-1. If the preceding `OP_IF` or `OP_NOTIF` condition was met (and its script executed), skip the opcodes following `OP_ELSE` until an [`OP_ENDIF`](./OP_ENDIF.md) is encountered.
-2. If the preceding condition was not met, execute the opcodes after `OP_ELSE` until an `OP_ENDIF` is found.
+1. If the preceding [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md) condition was met (and its script executed), skip the opcodes following [`OP_ELSE`](./OP_ELSE.md) until an [`OP_ENDIF`](./OP_ENDIF.md) is encountered.
+2. If the preceding condition was not met, execute the opcodes after [`OP_ELSE`](./OP_ELSE.md) until an [`OP_ENDIF`](./OP_ENDIF.md) is found.
 
 The structure generally appears like so:
 ```txt
@@ -20,7 +20,7 @@ OP_ELSE
 OP_ENDIF
 ```
 
-Or, in conjunction with `OP_NOTIF`:
+Or, in conjunction with [`OP_NOTIF`](./OP_NOTIF.md):
 ```txt
 <condition> OP_NOTIF
     <script if condition is false>
@@ -32,12 +32,12 @@ OP_ENDIF
 Where `<condition>` is an operation or value that results in a `0` or non-`0` value on top of the stack.
 
 ## Notes
-- `OP_ELSE` is not standalone and must be used within an `OP_IF`/`OP_NOTIF` and `OP_ENDIF` structure.
-- A script will fail and not complete if there is no matching `OP_ENDIF` for an `OP_ELSE`.
+- [`OP_ELSE`](./OP_ELSE.md) is not standalone and must be used within an [`OP_IF`](./OP_IF.md)/[`OP_NOTIF`](./OP_NOTIF.md) and [`OP_ENDIF`](./OP_ENDIF.md) structure.
+- A script will fail and not complete if there is no matching [`OP_ENDIF`](./OP_ENDIF.md) for an [`OP_ELSE`](./OP_ELSE.md).
 
 ## Examples
 ### Example 1
-The following script leaves `2` on the stack since the condition (`1`) is true in front of an `OP_IF``.
+The following script leaves `2` on the stack since the condition (`1`) is true in front of an [`OP_IF`](./OP_IF.md)`.
 ```shell
 # ASM script
 OP_1 OP_IF OP_2 OP_ELSE OP_3 OP_ENDIF
@@ -50,7 +50,7 @@ OP_1 OP_IF OP_2 OP_ELSE OP_3 OP_ENDIF
 ```
 
 ### Example 2
-The following script leaves `3` on the stack since the condition (`1`) is true in front of an `OP_NOTIF`.
+The following script leaves `3` on the stack since the condition (`1`) is true in front of an [`OP_NOTIF`](./OP_NOTIF.md).
 ```shell
 # ASM script
 OP_1 OP_NOTIF OP_2 OP_ELSE OP_3 OP_ENDIF

--- a/opcodes/OP_ENDIF.md
+++ b/opcodes/OP_ENDIF.md
@@ -5,17 +5,17 @@
 **Short description:** Ends a conditional block.
 :::
 
-`OP_ENDIF` is used to conclude conditional structures in Bitcoin scripting initiated by `OP_IF` or `OP_NOTIF`. It denotes the end of the conditional execution paths and allows the script to continue with any subsequent commands outside of the conditional block.
+[`OP_ENDIF`](./OP_ENDIF.md) is used to conclude conditional structures in Bitcoin scripting initiated by [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md). It denotes the end of the conditional execution paths and allows the script to continue with any subsequent commands outside of the conditional block.
 
 ### Operation
-1. Continue executing the following opcodes in the script after the `OP_ENDIF`.
+1. Continue executing the following opcodes in the script after the [`OP_ENDIF`](./OP_ENDIF.md).
 
-Note that `OP_ENDIF` itself does not directly cause any action other than marking the end of the conditional segment. Its presence ensures that the preceding conditional logic (whether that's an `OP_IF`, `OP_NOTIF`, or an accompanying `OP_ELSE`) has been properly closed.
+Note that [`OP_ENDIF`](./OP_ENDIF.md) itself does not directly cause any action other than marking the end of the conditional segment. Its presence ensures that the preceding conditional logic (whether that's an [`OP_IF`](./OP_IF.md), [`OP_NOTIF`](./OP_NOTIF.md), or an accompanying [`OP_ELSE`](./OP_ELSE.md)) has been properly closed.
 
 ## Notes
-- Each `OP_IF` or `OP_NOTIF` must have a corresponding `OP_ENDIF`. Failing to do so will render the script invalid.
-- A script can have nested `OP_IF`/`OP_NOTIF` structures, but each of them must be properly closed with their own `OP_ENDIF`.
-- A script with an `OP_ENDIF` without a preceding `OP_IF` or `OP_NOTIF` is also invalid.
+- Each [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md) must have a corresponding [`OP_ENDIF`](./OP_ENDIF.md). Failing to do so will render the script invalid.
+- A script can have nested [`OP_IF`](./OP_IF.md)/[`OP_NOTIF`](./OP_NOTIF.md) structures, but each of them must be properly closed with their own [`OP_ENDIF`](./OP_ENDIF.md).
+- A script with an [`OP_ENDIF`](./OP_ENDIF.md) without a preceding [`OP_IF`](./OP_IF.md) or [`OP_NOTIF`](./OP_NOTIF.md) is also invalid.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_FROMALTSTACK.md
+++ b/opcodes/OP_FROMALTSTACK.md
@@ -5,7 +5,7 @@
 **Short description:** Moves the top item from the alternate stack to the main stack.
 :::
 
-`OP_FROMALTSTACK` is used for transferring data between the alternate stack and the main stack.
+[`OP_FROMALTSTACK`](./OP_FROMALTSTACK.md) is used for transferring data between the alternate stack and the main stack.
 
 :::warning
 This page is not well developed. If you think you can contribute to this page, please consider helping us out by [opening a pull request on the repo](https://github.com/thunderbiscuit/opcode-explained)!
@@ -18,12 +18,12 @@ This page is not well developed. If you think you can contribute to this page, p
 The alternate stack serves as a secondary storage space during script execution, separate from the main stack. This opcode enables the movement of data from this auxiliary stack back to the main stack.
 
 ### Use Cases
-- **Retrieving Data:** Scripts can use `OP_FROMALTSTACK` to retrieve data previously stored on the alternate stack, allowing for more intricate scripting logic.
+- **Retrieving Data:** Scripts can use [`OP_FROMALTSTACK`](./OP_FROMALTSTACK.md) to retrieve data previously stored on the alternate stack, allowing for more intricate scripting logic.
 - **Script Organization:** By using both the main and alternate stacks, scripts can maintain cleaner and more organized operations, especially in complex scripts.
 
 ### Notes
 - The alternate stack is an essential tool for complex script logic, enabling temporary storage and retrieval of data.
-- `OP_FROMALTSTACK` is commonly used in conjunction with [`OP_TOALTSTACK`](./OP_TOALTSTACK.md) for effective data manipulation between the two stacks.
+- [`OP_FROMALTSTACK`](./OP_FROMALTSTACK.md) is commonly used in conjunction with [`OP_TOALTSTACK`](./OP_TOALTSTACK.md) for effective data manipulation between the two stacks.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_IF.md
+++ b/opcodes/OP_IF.md
@@ -5,12 +5,12 @@
 **Short description:** Pop and execute the next statements if a nonzero element was popped.
 :::
 
-`OP_IF` is used to perform conditional execution. Scripts in Bitcoin can contain branches—parts of the script that are executed only if certain conditions are met. The `OP_IF` opcode allows the script to evaluate a value and conditionally execute the following script commands based on that value.
+[`OP_IF`](./OP_IF.md) is used to perform conditional execution. Scripts in Bitcoin can contain branches—parts of the script that are executed only if certain conditions are met. The [`OP_IF`](./OP_IF.md) opcode allows the script to evaluate a value and conditionally execute the following script commands based on that value.
 
 ### Operation
 1. Pop the top stack item.
 2. If the item is not `0`, execute the following opcodes until an [`OP_ELSE`](./OP_ELSE.md) or [`OP_ENDIF`](./OP_ENDIF.md) is encountered.
-3. If the item is `0`, skip the following opcodes until an `OP_ELSE` or `OP_ENDIF` is encountered.
+3. If the item is `0`, skip the following opcodes until an [`OP_ELSE`](./OP_ELSE.md) or [`OP_ENDIF`](./OP_ENDIF.md) is encountered.
 
 You'll see it used like so:
 ```txt
@@ -25,7 +25,7 @@ Where `<condition>` is some operation or value that will leave a `0` or non-`0` 
 
 ## Notes
 - Bitcoin script does not support loop structures, so all conditional logic is based on branches.
-- The script will fail and not complete if there is no matching `OP_ENDIF` for an `OP_IF`.
+- The script will fail and not complete if there is no matching [`OP_ENDIF`](./OP_ENDIF.md) for an [`OP_IF`](./OP_IF.md).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_INVERT.md
+++ b/opcodes/OP_INVERT.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_INVERT` is a disabled opcode in the Bitcoin scripting system.
+[`OP_INVERT`](./OP_INVERT.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-Originally, the `OP_INVERT` opcode was intended to invert all the bits of the top item on the stack. This bitwise operation would flip every 1 to 0 and every 0 to 1 in the binary representation of the number.
+Originally, the [`OP_INVERT`](./OP_INVERT.md) opcode was intended to invert all the bits of the top item on the stack. This bitwise operation would flip every 1 to 0 and every 0 to 1 in the binary representation of the number.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_INVERT` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_INVERT`](./OP_INVERT.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_INVERT` is disabled, any script that contains it will result in the transaction being labeled as invalid, regardless of the overall script context.
+Because [`OP_INVERT`](./OP_INVERT.md) is disabled, any script that contains it will result in the transaction being labeled as invalid, regardless of the overall script context.

--- a/opcodes/OP_LEFT.md
+++ b/opcodes/OP_LEFT.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_LEFT` is a disabled opcode in the Bitcoin scripting system.
+[`OP_LEFT`](./OP_LEFT.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-Originally, the `OP_LEFT` opcode was intended to keep only the leftmost N bytes of a string. The operation would pop two items from the stack: the original string and a byte count. It would then push back onto the stack the leftmost bytes of the string, as specified by the byte count.
+Originally, the [`OP_LEFT`](./OP_LEFT.md) opcode was intended to keep only the leftmost N bytes of a string. The operation would pop two items from the stack: the original string and a byte count. It would then push back onto the stack the leftmost bytes of the string, as specified by the byte count.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_LEFT` (along with several other string manipulation opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_LEFT`](./OP_LEFT.md) (along with several other string manipulation opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_LEFT` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_LEFT`](./OP_LEFT.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_LSHIFT.md
+++ b/opcodes/OP_LSHIFT.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_LSHIFT` is a disabled opcode in the Bitcoin scripting system.
+[`OP_LSHIFT`](./OP_LSHIFT.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-`OP_LSHIFT` was intended for bitwise left shift operations, which would shift the bits of the top stack item to the left by a number of positions specified by the second-to-top stack item.
+[`OP_LSHIFT`](./OP_LSHIFT.md) was intended for bitwise left shift operations, which would shift the bits of the top stack item to the left by a number of positions specified by the second-to-top stack item.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_LSHIFT` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_LSHIFT`](./OP_LSHIFT.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_LSHIFT` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_LSHIFT`](./OP_LSHIFT.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_MOD.md
+++ b/opcodes/OP_MOD.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_MOD` is a disabled opcode in the bitcoin scripting system.
+[`OP_MOD`](./OP_MOD.md) is a disabled opcode in the bitcoin scripting system.
 
 ### Historical Context
-`OP_MOD` was designed to perform a modulus operation, which would find the remainder after dividing the second-to-top stack item by the top stack item.
+[`OP_MOD`](./OP_MOD.md) was designed to perform a modulus operation, which would find the remainder after dividing the second-to-top stack item by the top stack item.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_MOD` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_MOD`](./OP_MOD.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_MOD` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_MOD`](./OP_MOD.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_MUL.md
+++ b/opcodes/OP_MUL.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_MUL` is a disabled opcode in the Bitcoin scripting system.
+[`OP_MUL`](./OP_MUL.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-`OP_MUL` was intended to perform multiplication operations between the two topmost items on the stack.
+[`OP_MUL`](./OP_MUL.md) was intended to perform multiplication operations between the two topmost items on the stack.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_MUL` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_MUL`](./OP_MUL.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_MUL` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_MUL`](./OP_MUL.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_NOP.md
+++ b/opcodes/OP_NOP.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP` opcode does nothing.
+The [`OP_NOP`](./OP_NOP.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP1.md
+++ b/opcodes/OP_NOP1.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP1` opcode does nothing.
+The [`OP_NOP1`](./OP_NOP1.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP10.md
+++ b/opcodes/OP_NOP10.md
@@ -9,7 +9,7 @@
 This page would like some review. If you'd like to contribute, take a look at the [source code for this website]!
 :::
 
-The `OP_NOP10` opcode does nothing. It does not change the state of the stack or any of the script's execution conditions.
+The [`OP_NOP10`](./OP_NOP10.md) opcode does nothing. It does not change the state of the stack or any of the script's execution conditions.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP4.md
+++ b/opcodes/OP_NOP4.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP4` opcode does nothing.
+The [`OP_NOP4`](./OP_NOP4.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP5.md
+++ b/opcodes/OP_NOP5.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP5` opcode does nothing.
+The [`OP_NOP5`](./OP_NOP5.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP6.md
+++ b/opcodes/OP_NOP6.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP6` opcode does nothing.
+The [`OP_NOP6`](./OP_NOP6.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP7.md
+++ b/opcodes/OP_NOP7.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP7` opcode does nothing.
+The [`OP_NOP7`](./OP_NOP7.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP8.md
+++ b/opcodes/OP_NOP8.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP8` opcode does nothing.
+The [`OP_NOP8`](./OP_NOP8.md) opcode does nothing.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOP9.md
+++ b/opcodes/OP_NOP9.md
@@ -9,7 +9,7 @@ This page would like some review. If you'd like to contribute, take a look at th
 **Short Description:** Does nothing. 
 :::
 
-The `OP_NOP9` opcode does nothing. It does not change the state of the stack or any of the script's execution conditions.
+The [`OP_NOP9`](./OP_NOP9.md) opcode does nothing. It does not change the state of the stack or any of the script's execution conditions.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_NOTIF.md
+++ b/opcodes/OP_NOTIF.md
@@ -5,7 +5,7 @@
 **Short description:** Pop and execute the next statements if a zero element was popped.
 :::
 
-`OP_NOTIF` is used to perform conditional execution, similar to [`OP_IF`](./OP_IF.md) but operates inversely. Scripts will execute the next segment if a zero element is popped from the stack.
+[`OP_NOTIF`](./OP_NOTIF.md) is used to perform conditional execution, similar to [`OP_IF`](./OP_IF.md) but operates inversely. Scripts will execute the next segment if a zero element is popped from the stack.
 
 ### Operation
 1. Pop the top stack item.

--- a/opcodes/OP_OR.md
+++ b/opcodes/OP_OR.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_OR` is a disabled opcode in the bitcoin scripting system.
+[`OP_OR`](./OP_OR.md) is a disabled opcode in the bitcoin scripting system.
 
 ### Historical Context
-Originally, `OP_OR` was intended to perform a bitwise OR operation on the top two items on the stack. This operation would take two numbers and produce a new number. In this result, each bit is the logical OR of the corresponding bits in the input numbers.
+Originally, [`OP_OR`](./OP_OR.md) was intended to perform a bitwise OR operation on the top two items on the stack. This operation would take two numbers and produce a new number. In this result, each bit is the logical OR of the corresponding bits in the input numbers.
 
-However, as part of a broader effort to reduce potential vulnerabilities and to simplify bitcoin's scripting language, `OP_OR` was disabled early in bitcoin's history along with several other opcodes.
+However, as part of a broader effort to reduce potential vulnerabilities and to simplify bitcoin's scripting language, [`OP_OR`](./OP_OR.md) was disabled early in bitcoin's history along with several other opcodes.
 
 ### Operation
-Because `OP_OR` is disabled, any script that includes it will result in the transaction being declared invalid, irrespective of the script's overall context.
+Because [`OP_OR`](./OP_OR.md) is disabled, any script that includes it will result in the transaction being declared invalid, irrespective of the script's overall context.

--- a/opcodes/OP_PUSHBYTES_1.md
+++ b/opcodes/OP_PUSHBYTES_1.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next byte onto the stack. 
 :::
 
-The `OP_PUSHBYTES_1` opcode will push the following byte onto the stack. For the bytes `0x01` to `0x10` it is more efficient (and required by standardness rules) to use opcodes `OP_1` to `OP_16`, and for the byte `0x81` to use `OP_1NEGATE` (see [minimal push operations](../script/push.md#minimal-push-operations)).
+The [`OP_PUSHBYTES_1`](./OP_PUSHBYTES_1.md) opcode will push the following byte onto the stack. For the bytes `0x01` to `0x10` it is more efficient (and required by standardness rules) to use opcodes [`OP_1`](./OP_1.md) to [`OP_16`](./OP_16.md), and for the byte `0x81` to use [`OP_1NEGATE`](./OP_1NEGATE.md) (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_10.md
+++ b/opcodes/OP_PUSHBYTES_10.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 10 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_10` opcode will push the following 10 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_10`](./OP_PUSHBYTES_10.md) opcode will push the following 10 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_11.md
+++ b/opcodes/OP_PUSHBYTES_11.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 11 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_11` opcode will push the following 11 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_11`](./OP_PUSHBYTES_11.md) opcode will push the following 11 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_12.md
+++ b/opcodes/OP_PUSHBYTES_12.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 12 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_12` opcode will push the following 12 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_12`](./OP_PUSHBYTES_12.md) opcode will push the following 12 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_13.md
+++ b/opcodes/OP_PUSHBYTES_13.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 13 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_13` opcode will push the following 13 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_13`](./OP_PUSHBYTES_13.md) opcode will push the following 13 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_14.md
+++ b/opcodes/OP_PUSHBYTES_14.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 14 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_14` opcode will push the following 14 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_14`](./OP_PUSHBYTES_14.md) opcode will push the following 14 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_15.md
+++ b/opcodes/OP_PUSHBYTES_15.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 15 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_15` opcode will push the following 15 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_15`](./OP_PUSHBYTES_15.md) opcode will push the following 15 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_16.md
+++ b/opcodes/OP_PUSHBYTES_16.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 16 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_16` opcode will push the following 16 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_16`](./OP_PUSHBYTES_16.md) opcode will push the following 16 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_17.md
+++ b/opcodes/OP_PUSHBYTES_17.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 17 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_17` opcode will push the following 17 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_17`](./OP_PUSHBYTES_17.md) opcode will push the following 17 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_18.md
+++ b/opcodes/OP_PUSHBYTES_18.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 18 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_18` opcode will push the following 18 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_18`](./OP_PUSHBYTES_18.md) opcode will push the following 18 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_19.md
+++ b/opcodes/OP_PUSHBYTES_19.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 19 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_19` opcode will push the following 19 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_19`](./OP_PUSHBYTES_19.md) opcode will push the following 19 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_2.md
+++ b/opcodes/OP_PUSHBYTES_2.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 2 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_2` opcode will push the following 2 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_2`](./OP_PUSHBYTES_2.md) opcode will push the following 2 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_PUSHBYTES_20.md
+++ b/opcodes/OP_PUSHBYTES_20.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 20 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_20` opcode will push the following 20 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_20`](./OP_PUSHBYTES_20.md) opcode will push the following 20 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_21.md
+++ b/opcodes/OP_PUSHBYTES_21.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 21 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_21` opcode will push the following 21 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_21`](./OP_PUSHBYTES_21.md) opcode will push the following 21 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_22.md
+++ b/opcodes/OP_PUSHBYTES_22.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 22 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_22` opcode will push the following 22 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_22`](./OP_PUSHBYTES_22.md) opcode will push the following 22 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_23.md
+++ b/opcodes/OP_PUSHBYTES_23.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 23 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_23` opcode will push the following 23 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_23`](./OP_PUSHBYTES_23.md) opcode will push the following 23 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_24.md
+++ b/opcodes/OP_PUSHBYTES_24.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 24 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_24` opcode will push the following 24 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_24`](./OP_PUSHBYTES_24.md) opcode will push the following 24 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_25.md
+++ b/opcodes/OP_PUSHBYTES_25.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 25 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_25` opcode will push the following 25 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_25`](./OP_PUSHBYTES_25.md) opcode will push the following 25 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_26.md
+++ b/opcodes/OP_PUSHBYTES_26.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 26 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_26` opcode will push the following 26 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_26`](./OP_PUSHBYTES_26.md) opcode will push the following 26 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_27.md
+++ b/opcodes/OP_PUSHBYTES_27.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 27 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_27` opcode will push the following 27 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_27`](./OP_PUSHBYTES_27.md) opcode will push the following 27 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_28.md
+++ b/opcodes/OP_PUSHBYTES_28.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 28 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_28` opcode will push the following 28 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_28`](./OP_PUSHBYTES_28.md) opcode will push the following 28 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_29.md
+++ b/opcodes/OP_PUSHBYTES_29.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 29 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_29` opcode will push the following 29 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_29`](./OP_PUSHBYTES_29.md) opcode will push the following 29 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_3.md
+++ b/opcodes/OP_PUSHBYTES_3.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 3 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_3` opcode will push the following 3 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_3`](./OP_PUSHBYTES_3.md) opcode will push the following 3 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_30.md
+++ b/opcodes/OP_PUSHBYTES_30.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 30 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_30` opcode will push the following 30 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_30`](./OP_PUSHBYTES_30.md) opcode will push the following 30 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_31.md
+++ b/opcodes/OP_PUSHBYTES_31.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 31 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_31` opcode will push the following 31 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_31`](./OP_PUSHBYTES_31.md) opcode will push the following 31 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_32.md
+++ b/opcodes/OP_PUSHBYTES_32.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 32 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_32` opcode will push the following 32 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_32`](./OP_PUSHBYTES_32.md) opcode will push the following 32 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_33.md
+++ b/opcodes/OP_PUSHBYTES_33.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 33 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_33` opcode will push the following 33 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_33`](./OP_PUSHBYTES_33.md) opcode will push the following 33 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_34.md
+++ b/opcodes/OP_PUSHBYTES_34.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 34 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_34` opcode will push the following 34 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_34`](./OP_PUSHBYTES_34.md) opcode will push the following 34 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_35.md
+++ b/opcodes/OP_PUSHBYTES_35.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 35 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_35` opcode will push the following 35 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_35`](./OP_PUSHBYTES_35.md) opcode will push the following 35 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_36.md
+++ b/opcodes/OP_PUSHBYTES_36.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 36 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_36` opcode will push the following 36 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_36`](./OP_PUSHBYTES_36.md) opcode will push the following 36 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_37.md
+++ b/opcodes/OP_PUSHBYTES_37.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 37 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_37` opcode will push the following 37 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_37`](./OP_PUSHBYTES_37.md) opcode will push the following 37 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_38.md
+++ b/opcodes/OP_PUSHBYTES_38.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 38 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_38` opcode will push the following 38 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_38`](./OP_PUSHBYTES_38.md) opcode will push the following 38 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_39.md
+++ b/opcodes/OP_PUSHBYTES_39.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 39 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_39` opcode will push the following 39 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_39`](./OP_PUSHBYTES_39.md) opcode will push the following 39 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_4.md
+++ b/opcodes/OP_PUSHBYTES_4.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 4 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_4` opcode will push the following 4 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_4`](./OP_PUSHBYTES_4.md) opcode will push the following 4 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_40.md
+++ b/opcodes/OP_PUSHBYTES_40.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 40 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_40` opcode will push the following 40 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_40`](./OP_PUSHBYTES_40.md) opcode will push the following 40 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_41.md
+++ b/opcodes/OP_PUSHBYTES_41.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 41 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_41` opcode will push the following 41 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_41`](./OP_PUSHBYTES_41.md) opcode will push the following 41 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_42.md
+++ b/opcodes/OP_PUSHBYTES_42.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 42 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_42` opcode will push the following 42 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_42`](./OP_PUSHBYTES_42.md) opcode will push the following 42 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_43.md
+++ b/opcodes/OP_PUSHBYTES_43.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 43 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_43` opcode will push the following 43 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_43`](./OP_PUSHBYTES_43.md) opcode will push the following 43 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_44.md
+++ b/opcodes/OP_PUSHBYTES_44.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 44 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_44` opcode will push the following 44 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_44`](./OP_PUSHBYTES_44.md) opcode will push the following 44 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_45.md
+++ b/opcodes/OP_PUSHBYTES_45.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 45 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_45` opcode will push the following 45 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_45`](./OP_PUSHBYTES_45.md) opcode will push the following 45 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_46.md
+++ b/opcodes/OP_PUSHBYTES_46.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 46 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_46` opcode will push the following 46 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_46`](./OP_PUSHBYTES_46.md) opcode will push the following 46 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_47.md
+++ b/opcodes/OP_PUSHBYTES_47.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 47 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_47` opcode will push the following 47 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_47`](./OP_PUSHBYTES_47.md) opcode will push the following 47 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_48.md
+++ b/opcodes/OP_PUSHBYTES_48.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 48 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_48` opcode will push the following 48 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_48`](./OP_PUSHBYTES_48.md) opcode will push the following 48 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_49.md
+++ b/opcodes/OP_PUSHBYTES_49.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 49 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_49` opcode will push the following 49 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_49`](./OP_PUSHBYTES_49.md) opcode will push the following 49 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_5.md
+++ b/opcodes/OP_PUSHBYTES_5.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 5 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_5` opcode will push the following 5 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_5`](./OP_PUSHBYTES_5.md) opcode will push the following 5 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_50.md
+++ b/opcodes/OP_PUSHBYTES_50.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 50 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_50` opcode will push the following 50 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_50`](./OP_PUSHBYTES_50.md) opcode will push the following 50 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_51.md
+++ b/opcodes/OP_PUSHBYTES_51.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 51 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_51` opcode will push the following 51 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_51`](./OP_PUSHBYTES_51.md) opcode will push the following 51 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_52.md
+++ b/opcodes/OP_PUSHBYTES_52.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 52 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_52` opcode will push the following 52 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_52`](./OP_PUSHBYTES_52.md) opcode will push the following 52 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_53.md
+++ b/opcodes/OP_PUSHBYTES_53.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 53 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_53` opcode will push the following 53 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_53`](./OP_PUSHBYTES_53.md) opcode will push the following 53 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_54.md
+++ b/opcodes/OP_PUSHBYTES_54.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 54 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_54` opcode will push the following 54 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_54`](./OP_PUSHBYTES_54.md) opcode will push the following 54 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_55.md
+++ b/opcodes/OP_PUSHBYTES_55.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 55 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_55` opcode will push the following 55 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_55`](./OP_PUSHBYTES_55.md) opcode will push the following 55 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_56.md
+++ b/opcodes/OP_PUSHBYTES_56.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 56 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_56` opcode will push the following 56 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_56`](./OP_PUSHBYTES_56.md) opcode will push the following 56 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_57.md
+++ b/opcodes/OP_PUSHBYTES_57.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 57 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_57` opcode will push the following 57 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_57`](./OP_PUSHBYTES_57.md) opcode will push the following 57 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_58.md
+++ b/opcodes/OP_PUSHBYTES_58.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 58 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_58` opcode will push the following 58 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_58`](./OP_PUSHBYTES_58.md) opcode will push the following 58 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_59.md
+++ b/opcodes/OP_PUSHBYTES_59.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 59 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_59` opcode will push the following 59 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_59`](./OP_PUSHBYTES_59.md) opcode will push the following 59 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_6.md
+++ b/opcodes/OP_PUSHBYTES_6.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 6 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_6` opcode will push the following 6 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_6`](./OP_PUSHBYTES_6.md) opcode will push the following 6 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_60.md
+++ b/opcodes/OP_PUSHBYTES_60.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 60 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_60` opcode will push the following 60 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_60`](./OP_PUSHBYTES_60.md) opcode will push the following 60 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_61.md
+++ b/opcodes/OP_PUSHBYTES_61.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 61 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_61` opcode will push the following 61 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_61`](./OP_PUSHBYTES_61.md) opcode will push the following 61 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_62.md
+++ b/opcodes/OP_PUSHBYTES_62.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 62 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_62` opcode will push the following 62 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_62`](./OP_PUSHBYTES_62.md) opcode will push the following 62 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_63.md
+++ b/opcodes/OP_PUSHBYTES_63.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 63 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_63` opcode will push the following 63 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_63`](./OP_PUSHBYTES_63.md) opcode will push the following 63 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_64.md
+++ b/opcodes/OP_PUSHBYTES_64.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 64 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_64` opcode will push the following 64 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_64`](./OP_PUSHBYTES_64.md) opcode will push the following 64 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_65.md
+++ b/opcodes/OP_PUSHBYTES_65.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 65 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_65` opcode will push the following 65 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_65`](./OP_PUSHBYTES_65.md) opcode will push the following 65 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_66.md
+++ b/opcodes/OP_PUSHBYTES_66.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 66 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_66` opcode will push the following 66 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_66`](./OP_PUSHBYTES_66.md) opcode will push the following 66 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_67.md
+++ b/opcodes/OP_PUSHBYTES_67.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 67 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_67` opcode will push the following 67 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_67`](./OP_PUSHBYTES_67.md) opcode will push the following 67 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_68.md
+++ b/opcodes/OP_PUSHBYTES_68.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 68 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_68` opcode will push the following 68 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_68`](./OP_PUSHBYTES_68.md) opcode will push the following 68 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_69.md
+++ b/opcodes/OP_PUSHBYTES_69.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 69 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_69` opcode will push the following 69 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_69`](./OP_PUSHBYTES_69.md) opcode will push the following 69 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_7.md
+++ b/opcodes/OP_PUSHBYTES_7.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 7 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_7` opcode will push the following 7 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_7`](./OP_PUSHBYTES_7.md) opcode will push the following 7 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_70.md
+++ b/opcodes/OP_PUSHBYTES_70.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 70 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_70` opcode will push the following 70 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_70`](./OP_PUSHBYTES_70.md) opcode will push the following 70 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_71.md
+++ b/opcodes/OP_PUSHBYTES_71.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 71 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_71` opcode will push the following 71 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_71`](./OP_PUSHBYTES_71.md) opcode will push the following 71 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_72.md
+++ b/opcodes/OP_PUSHBYTES_72.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 72 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_72` opcode will push the following 72 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_72`](./OP_PUSHBYTES_72.md) opcode will push the following 72 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_73.md
+++ b/opcodes/OP_PUSHBYTES_73.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 73 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_73` opcode will push the following 73 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_73`](./OP_PUSHBYTES_73.md) opcode will push the following 73 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_74.md
+++ b/opcodes/OP_PUSHBYTES_74.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 74 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_74` opcode will push the following 74 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_74`](./OP_PUSHBYTES_74.md) opcode will push the following 74 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_75.md
+++ b/opcodes/OP_PUSHBYTES_75.md
@@ -5,7 +5,7 @@
 **Short description:** Push the next 75 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_75` opcode will push the following 75 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_75`](./OP_PUSHBYTES_75.md) opcode will push the following 75 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_8.md
+++ b/opcodes/OP_PUSHBYTES_8.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 8 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_8` opcode will push the following 8 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_8`](./OP_PUSHBYTES_8.md) opcode will push the following 8 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHBYTES_9.md
+++ b/opcodes/OP_PUSHBYTES_9.md
@@ -5,7 +5,7 @@
 **Short Description:** Push the next 9 bytes onto the stack. 
 :::
 
-The `OP_PUSHBYTES_9` opcode will push the following 9 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
+The [`OP_PUSHBYTES_9`](./OP_PUSHBYTES_9.md) opcode will push the following 9 bytes onto the stack. It's part of a group of opcodes that push a specific number of bytes onto the stack, from [OP_PUSHBYTES_1](./OP_PUSHBYTES_1.md) to [OP_PUSHBYTES_75](./OP_PUSHBYTES_75.md).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHDATA1.md
+++ b/opcodes/OP_PUSHDATA1.md
@@ -5,9 +5,9 @@
 **Short description:** Read the next byte as `N`. Push the next `N` bytes as an array onto the stack.
 :::
 
-The `OP_PUSHDATA1` opcode will read the byte that follows it and interpret it as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads a single byte and inteprets it as a number, this opcode can push any number of bytes from 0 to 255. Note that for any number of bytes under 76, it is more efficient (and required by standardness rules) to use opcodes in the `OP_PUSHBYTES` family, or more specific opcodes where applicable (see [minimal push operations](../script/push.md#minimal-push-operations)).
+The [`OP_PUSHDATA1`](./OP_PUSHDATA1.md) opcode will read the byte that follows it and interpret it as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads a single byte and inteprets it as a number, this opcode can push any number of bytes from 0 to 255. Note that for any number of bytes under 76, it is more efficient (and required by standardness rules) to use opcodes in the `OP_PUSHBYTES` family, or more specific opcodes where applicable (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
-`OP_PUSHDATA1` is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA2](./OP_PUSHDATA2.md) and [OP_PUSHDATA4](./OP_PUSHDATA4.md)).
+[`OP_PUSHDATA1`](./OP_PUSHDATA1.md) is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA2](./OP_PUSHDATA2.md) and [OP_PUSHDATA4](./OP_PUSHDATA4.md)).
 
 ## Example
 ```shell

--- a/opcodes/OP_PUSHDATA2.md
+++ b/opcodes/OP_PUSHDATA2.md
@@ -5,9 +5,9 @@
 **Short description:** Read the next 2 bytes as `N`. Push the next `N` bytes as an array onto the stack.
 :::
 
-The `OP_PUSHDATA2` opcode will read the 2 bytes that follow it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 2 bytes and inteprets them as a number, this opcode can push any number of bytes from 0 to 65,535, though consensus rules only allow at most 520 bytes in one push. Note that for any number of bytes between 76 and 255, it is more efficient (and required by standardness rules) to use `OP_PUSHDATA1`, and for any number of bytes under 76, opcodes in the `OP_PUSHBYTES` family, or more specific opcodes where applicable (see [minimal push operations](../script/push.md#minimal-push-operations)).
+The [`OP_PUSHDATA2`](./OP_PUSHDATA2.md) opcode will read the 2 bytes that follow it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 2 bytes and inteprets them as a number, this opcode can push any number of bytes from 0 to 65,535, though consensus rules only allow at most 520 bytes in one push. Note that for any number of bytes between 76 and 255, it is more efficient (and required by standardness rules) to use [`OP_PUSHDATA1`](./OP_PUSHDATA1.md), and for any number of bytes under 76, opcodes in the `OP_PUSHBYTES` family, or more specific opcodes where applicable (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
-`OP_PUSHDATA2` is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA4](./OP_PUSHDATA4.md)).
+[`OP_PUSHDATA2`](./OP_PUSHDATA2.md) is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA4](./OP_PUSHDATA4.md)).
 
 ## Example
 This example pushes 400 bytes to the stack.

--- a/opcodes/OP_PUSHDATA4.md
+++ b/opcodes/OP_PUSHDATA4.md
@@ -5,6 +5,6 @@
 **Short description:** Read the next 4 bytes as `N`. Push the next `N` bytes as an array onto the stack.
 :::
 
-The `OP_PUSHDATA4` opcode will read the 4 bytes that follow it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 4 bytes and inteprets them as a number, this opcode can push any number of bytes from 0 to 4,294,967,295. Since the largest data push allowed by consensus rules is 520 bytes for which it is more efficient (and required by standardness rules) to use `OP_PUSHDATA2`, this opcode is never used in practice (see [minimal push operations](../script/push.md#minimal-push-operations)).
+The [`OP_PUSHDATA4`](./OP_PUSHDATA4.md) opcode will read the 4 bytes that follow it and interpret them as an integer. It will then push the next number of bytes this integer specifies onto the stack. Because it reads 4 bytes and inteprets them as a number, this opcode can push any number of bytes from 0 to 4,294,967,295. Since the largest data push allowed by consensus rules is 520 bytes for which it is more efficient (and required by standardness rules) to use [`OP_PUSHDATA2`](./OP_PUSHDATA2.md), this opcode is never used in practice (see [minimal push operations](../script/push.md#minimal-push-operations)).
 
-`OP_PUSHDATA4` is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA2](./OP_PUSHDATA2.md)).
+[`OP_PUSHDATA4`](./OP_PUSHDATA4.md) is part of a group of 3 opcodes that push a custom, user-specified number of bytes onto the stack (its sibling opcodes are [OP_PUSHDATA1](./OP_PUSHDATA1.md) and [OP_PUSHDATA2](./OP_PUSHDATA2.md)).

--- a/opcodes/OP_RESERVED.md
+++ b/opcodes/OP_RESERVED.md
@@ -5,4 +5,4 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RESERVED` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RESERVED`](./OP_RESERVED.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).

--- a/opcodes/OP_RETURN.md
+++ b/opcodes/OP_RETURN.md
@@ -5,16 +5,16 @@
 **Short description:** Fail the script immediatly (must be executed).
 :::
 
-`OP_RETURN` is an opcode in bitcoin's scripting system that allows for the inclusion of a small amount of arbitrary data in a transaction. This opcode immediately marks the transaction output as unspendable, ensuring that the output can't be used as an input in a subsequent transaction. It's primarily used to embed arbitrary data in the blockchain.
+[`OP_RETURN`](./OP_RETURN.md) is an opcode in bitcoin's scripting system that allows for the inclusion of a small amount of arbitrary data in a transaction. This opcode immediately marks the transaction output as unspendable, ensuring that the output can't be used as an input in a subsequent transaction. It's primarily used to embed arbitrary data in the blockchain.
 
 ### Operation
-1. Terminate the script execution unsuccessfully. Any transaction output with this opcode is not spendable, but the data after `OP_RETURN` remains permanently on the blockchain. It's a way of declaring that the output can't be spent, and it's only here for the data.
+1. Terminate the script execution unsuccessfully. Any transaction output with this opcode is not spendable, but the data after [`OP_RETURN`](./OP_RETURN.md) remains permanently on the blockchain. It's a way of declaring that the output can't be spent, and it's only here for the data.
 
 ## Notes
-- `OP_RETURN` is commonly followed by a pushdata operation that determines the length of the data to be embedded, and then the data itself.
-- The maximum number of bytes that can follow an `OP_RETURN` opcode is 80.
-- `OP_RETURN` outputs are used for various purposes, from proving the existence of a particular piece of data at a certain point in time to more complex protocols built on top of bitcoin.
-- Historically, there were debates around the use of `OP_RETURN` because embedding data into the bitcoin blockchain adds to its size without directly supporting the transfer of bitcoin.
+- [`OP_RETURN`](./OP_RETURN.md) is commonly followed by a pushdata operation that determines the length of the data to be embedded, and then the data itself.
+- The maximum number of bytes that can follow an [`OP_RETURN`](./OP_RETURN.md) opcode is 80.
+- [`OP_RETURN`](./OP_RETURN.md) outputs are used for various purposes, from proving the existence of a particular piece of data at a certain point in time to more complex protocols built on top of bitcoin.
+- Historically, there were debates around the use of [`OP_RETURN`](./OP_RETURN.md) because embedding data into the bitcoin blockchain adds to its size without directly supporting the transfer of bitcoin.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_RETURN_187.md
+++ b/opcodes/OP_RETURN_187.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_187` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_187`](./OP_RETURN_187.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_187` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_187` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_187`](./OP_RETURN_187.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_187`](./OP_RETURN_187.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_188.md
+++ b/opcodes/OP_RETURN_188.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_188` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_188`](./OP_RETURN_188.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_188` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_188`](./OP_RETURN_188.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_189.md
+++ b/opcodes/OP_RETURN_189.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_189` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_189`](./OP_RETURN_189.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_189` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_189`](./OP_RETURN_189.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_190.md
+++ b/opcodes/OP_RETURN_190.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_189` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_189`](./OP_RETURN_189.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_189` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_189`](./OP_RETURN_189.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_191.md
+++ b/opcodes/OP_RETURN_191.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_191` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_191`](./OP_RETURN_191.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_191` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_191`](./OP_RETURN_191.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_192.md
+++ b/opcodes/OP_RETURN_192.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_192` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_192`](./OP_RETURN_192.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_192` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_192`](./OP_RETURN_192.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_193.md
+++ b/opcodes/OP_RETURN_193.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_193` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_193`](./OP_RETURN_193.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_193` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_193`](./OP_RETURN_193.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_194.md
+++ b/opcodes/OP_RETURN_194.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_193` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_193`](./OP_RETURN_193.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_193` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_188` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_193`](./OP_RETURN_193.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_188`](./OP_RETURN_188.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_195.md
+++ b/opcodes/OP_RETURN_195.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_195` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_195`](./OP_RETURN_195.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_195` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_195` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_195`](./OP_RETURN_195.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_195`](./OP_RETURN_195.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_196.md
+++ b/opcodes/OP_RETURN_196.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_196` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_196`](./OP_RETURN_196.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_196` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_196` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_196`](./OP_RETURN_196.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_196`](./OP_RETURN_196.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_197.md
+++ b/opcodes/OP_RETURN_197.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_197` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_197`](./OP_RETURN_197.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_197` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_197` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_197`](./OP_RETURN_197.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_197`](./OP_RETURN_197.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_198.md
+++ b/opcodes/OP_RETURN_198.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_198` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_198`](./OP_RETURN_198.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_198` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_198` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_198`](./OP_RETURN_198.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_198`](./OP_RETURN_198.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_199.md
+++ b/opcodes/OP_RETURN_199.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_199` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_199`](./OP_RETURN_199.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_199` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_199` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_199`](./OP_RETURN_199.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_199`](./OP_RETURN_199.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_200.md
+++ b/opcodes/OP_RETURN_200.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_200` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_200`](./OP_RETURN_200.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_200` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_200` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_200`](./OP_RETURN_200.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_200`](./OP_RETURN_200.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_201.md
+++ b/opcodes/OP_RETURN_201.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_201` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_201`](./OP_RETURN_201.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_201` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_201` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_201`](./OP_RETURN_201.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_201`](./OP_RETURN_201.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_202.md
+++ b/opcodes/OP_RETURN_202.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_202` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_202`](./OP_RETURN_202.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_202` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_202` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_202`](./OP_RETURN_202.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_202`](./OP_RETURN_202.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_203.md
+++ b/opcodes/OP_RETURN_203.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_203` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_203`](./OP_RETURN_203.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_203` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_203` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_203`](./OP_RETURN_203.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_203`](./OP_RETURN_203.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_204.md
+++ b/opcodes/OP_RETURN_204.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_204` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_204`](./OP_RETURN_204.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_204` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_204` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_204`](./OP_RETURN_204.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_204`](./OP_RETURN_204.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_205.md
+++ b/opcodes/OP_RETURN_205.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_205` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_205`](./OP_RETURN_205.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_205` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_205` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_205`](./OP_RETURN_205.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_205`](./OP_RETURN_205.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_206.md
+++ b/opcodes/OP_RETURN_206.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_206` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_206`](./OP_RETURN_206.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_206` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_206` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_206`](./OP_RETURN_206.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_206`](./OP_RETURN_206.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_207.md
+++ b/opcodes/OP_RETURN_207.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_207` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_207`](./OP_RETURN_207.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_207` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_207` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_207`](./OP_RETURN_207.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_207`](./OP_RETURN_207.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_208.md
+++ b/opcodes/OP_RETURN_208.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_208` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_208`](./OP_RETURN_208.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_208` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_208` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_208`](./OP_RETURN_208.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_208`](./OP_RETURN_208.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_209.md
+++ b/opcodes/OP_RETURN_209.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_209` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_209`](./OP_RETURN_209.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_209` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_209` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_209`](./OP_RETURN_209.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_209`](./OP_RETURN_209.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_210.md
+++ b/opcodes/OP_RETURN_210.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_210` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_210`](./OP_RETURN_210.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_210` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_210` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_210`](./OP_RETURN_210.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_210`](./OP_RETURN_210.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_211.md
+++ b/opcodes/OP_RETURN_211.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_211` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_211`](./OP_RETURN_211.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_211` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_211` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_211`](./OP_RETURN_211.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_211`](./OP_RETURN_211.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_212.md
+++ b/opcodes/OP_RETURN_212.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_212` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_212`](./OP_RETURN_212.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_212` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_212` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_212`](./OP_RETURN_212.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_212`](./OP_RETURN_212.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_213.md
+++ b/opcodes/OP_RETURN_213.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_213` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_213`](./OP_RETURN_213.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_213` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_213` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_213`](./OP_RETURN_213.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_213`](./OP_RETURN_213.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_214.md
+++ b/opcodes/OP_RETURN_214.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_214` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_214`](./OP_RETURN_214.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_214` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_214` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_214`](./OP_RETURN_214.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_214`](./OP_RETURN_214.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_215.md
+++ b/opcodes/OP_RETURN_215.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_215` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_215`](./OP_RETURN_215.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_215` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_215` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_215`](./OP_RETURN_215.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_215`](./OP_RETURN_215.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_216.md
+++ b/opcodes/OP_RETURN_216.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_216` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_216`](./OP_RETURN_216.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_216` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_216` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_216`](./OP_RETURN_216.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_216`](./OP_RETURN_216.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_217.md
+++ b/opcodes/OP_RETURN_217.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_217` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_217`](./OP_RETURN_217.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_217` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_217` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_217`](./OP_RETURN_217.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_217`](./OP_RETURN_217.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_218.md
+++ b/opcodes/OP_RETURN_218.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_218` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_218`](./OP_RETURN_218.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_218` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_218` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_218`](./OP_RETURN_218.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_218`](./OP_RETURN_218.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_219.md
+++ b/opcodes/OP_RETURN_219.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_219` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_219`](./OP_RETURN_219.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_219` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_219` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_219`](./OP_RETURN_219.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_219`](./OP_RETURN_219.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_220.md
+++ b/opcodes/OP_RETURN_220.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_220` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_220`](./OP_RETURN_220.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_220` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_220` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_220`](./OP_RETURN_220.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_220`](./OP_RETURN_220.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_221.md
+++ b/opcodes/OP_RETURN_221.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_221` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_221`](./OP_RETURN_221.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_221` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_221` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_221`](./OP_RETURN_221.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_221`](./OP_RETURN_221.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_222.md
+++ b/opcodes/OP_RETURN_222.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_222` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_222`](./OP_RETURN_222.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_222` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_222` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_222`](./OP_RETURN_222.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_222`](./OP_RETURN_222.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_223.md
+++ b/opcodes/OP_RETURN_223.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_223` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_223`](./OP_RETURN_223.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_223` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_223` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_223`](./OP_RETURN_223.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_223`](./OP_RETURN_223.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_224.md
+++ b/opcodes/OP_RETURN_224.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_224` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_224`](./OP_RETURN_224.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_224` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_224` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_224`](./OP_RETURN_224.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_224`](./OP_RETURN_224.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_225.md
+++ b/opcodes/OP_RETURN_225.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_225` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_225`](./OP_RETURN_225.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_225` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_225` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_225`](./OP_RETURN_225.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_225`](./OP_RETURN_225.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_226.md
+++ b/opcodes/OP_RETURN_226.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_226` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_226`](./OP_RETURN_226.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_226` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_226` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_226`](./OP_RETURN_226.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_226`](./OP_RETURN_226.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_227.md
+++ b/opcodes/OP_RETURN_227.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_227` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_227`](./OP_RETURN_227.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_227` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_227` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_227`](./OP_RETURN_227.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_227`](./OP_RETURN_227.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_228.md
+++ b/opcodes/OP_RETURN_228.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_228` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_228`](./OP_RETURN_228.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_228` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_228` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_228`](./OP_RETURN_228.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_228`](./OP_RETURN_228.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_229.md
+++ b/opcodes/OP_RETURN_229.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_229` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_229`](./OP_RETURN_229.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_229` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_229` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_229`](./OP_RETURN_229.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_229`](./OP_RETURN_229.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_230.md
+++ b/opcodes/OP_RETURN_230.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_230` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_230`](./OP_RETURN_230.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_230` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_230` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_230`](./OP_RETURN_230.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_230`](./OP_RETURN_230.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_231.md
+++ b/opcodes/OP_RETURN_231.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_231` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_231`](./OP_RETURN_231.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_231` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_231` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_231`](./OP_RETURN_231.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_231`](./OP_RETURN_231.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_232.md
+++ b/opcodes/OP_RETURN_232.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_232` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_232`](./OP_RETURN_232.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_232` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_232` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_232`](./OP_RETURN_232.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_232`](./OP_RETURN_232.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_233.md
+++ b/opcodes/OP_RETURN_233.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_233` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_233`](./OP_RETURN_233.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_233` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_233` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_233`](./OP_RETURN_233.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_233`](./OP_RETURN_233.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_234.md
+++ b/opcodes/OP_RETURN_234.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_234` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_234`](./OP_RETURN_234.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_234` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_234` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_234`](./OP_RETURN_234.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_234`](./OP_RETURN_234.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_235.md
+++ b/opcodes/OP_RETURN_235.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_235` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_235`](./OP_RETURN_235.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_235` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_235` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_235`](./OP_RETURN_235.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_235`](./OP_RETURN_235.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_236.md
+++ b/opcodes/OP_RETURN_236.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_236` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_236`](./OP_RETURN_236.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_236` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_236` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_236`](./OP_RETURN_236.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_236`](./OP_RETURN_236.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_237.md
+++ b/opcodes/OP_RETURN_237.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_237` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_237`](./OP_RETURN_237.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_237` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_237` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_237`](./OP_RETURN_237.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_237`](./OP_RETURN_237.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_238.md
+++ b/opcodes/OP_RETURN_238.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_238` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_238`](./OP_RETURN_238.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_238` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_238` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_238`](./OP_RETURN_238.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_238`](./OP_RETURN_238.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_239.md
+++ b/opcodes/OP_RETURN_239.md
@@ -5,6 +5,6 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_RETURN_239` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_239`](./OP_RETURN_239.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
-`OP_RETURN_239` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_239` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_239`](./OP_RETURN_239.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_239`](./OP_RETURN_239.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_240.md
+++ b/opcodes/OP_RETURN_240.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf0`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_240` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_240`](./OP_RETURN_240.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_240` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_240` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_240`](./OP_RETURN_240.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_240`](./OP_RETURN_240.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_241.md
+++ b/opcodes/OP_RETURN_241.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf1`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_241` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_241`](./OP_RETURN_241.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_241` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_241` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_241`](./OP_RETURN_241.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_241`](./OP_RETURN_241.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_242.md
+++ b/opcodes/OP_RETURN_242.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf2`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_242` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_242`](./OP_RETURN_242.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_242` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_242` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_242`](./OP_RETURN_242.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_242`](./OP_RETURN_242.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_243.md
+++ b/opcodes/OP_RETURN_243.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf3`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_243` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_243`](./OP_RETURN_243.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_243` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_243` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_243`](./OP_RETURN_243.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_243`](./OP_RETURN_243.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_244.md
+++ b/opcodes/OP_RETURN_244.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf4`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_244` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_244`](./OP_RETURN_244.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_244` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_244` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_244`](./OP_RETURN_244.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_244`](./OP_RETURN_244.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_245.md
+++ b/opcodes/OP_RETURN_245.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf5`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_245` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_245`](./OP_RETURN_245.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_245` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_245` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_245`](./OP_RETURN_245.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_245`](./OP_RETURN_245.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_246.md
+++ b/opcodes/OP_RETURN_246.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf6`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_246` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_246`](./OP_RETURN_246.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_246` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_246` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_246`](./OP_RETURN_246.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_246`](./OP_RETURN_246.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_247.md
+++ b/opcodes/OP_RETURN_247.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf7`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_247` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_247`](./OP_RETURN_247.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_247` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_247` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_247`](./OP_RETURN_247.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_247`](./OP_RETURN_247.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_248.md
+++ b/opcodes/OP_RETURN_248.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf8`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_248` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_248`](./OP_RETURN_248.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_248` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_248` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_248`](./OP_RETURN_248.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_248`](./OP_RETURN_248.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_249.md
+++ b/opcodes/OP_RETURN_249.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xf9`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_249` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_249`](./OP_RETURN_249.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_249` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_249` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_249`](./OP_RETURN_249.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_249`](./OP_RETURN_249.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_250.md
+++ b/opcodes/OP_RETURN_250.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xfa`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_250` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_250`](./OP_RETURN_250.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_250` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_250` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_250`](./OP_RETURN_250.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_250`](./OP_RETURN_250.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_251.md
+++ b/opcodes/OP_RETURN_251.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xfb`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_251` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_251`](./OP_RETURN_251.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_251` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_251` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_251`](./OP_RETURN_251.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_251`](./OP_RETURN_251.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_252.md
+++ b/opcodes/OP_RETURN_252.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xfc`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_252` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_252`](./OP_RETURN_252.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_252` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_252` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_252`](./OP_RETURN_252.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_252`](./OP_RETURN_252.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_253.md
+++ b/opcodes/OP_RETURN_253.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xfd`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_253` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_253`](./OP_RETURN_253.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_253` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_253` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_253`](./OP_RETURN_253.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_253`](./OP_RETURN_253.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RETURN_254.md
+++ b/opcodes/OP_RETURN_254.md
@@ -4,8 +4,8 @@
 **Byte representation:** `0xfe`  
 **Short description:** Fail the script immediately.
 :::
-`OP_RETURN_254` fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_RETURN_254`](./OP_RETURN_254.md) fails the script immediately, but it must be executed (for example it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
 
 
 
-`OP_RETURN_254` is part of a group of opcodes that are not defined directly in bitcoin core, (the `OP_RETURN_254` name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.
+[`OP_RETURN_254`](./OP_RETURN_254.md) is part of a group of opcodes that are not defined directly in bitcoin core, (the [`OP_RETURN_254`](./OP_RETURN_254.md) name comes from [rust-bitcoin](https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/opcodes.rs.html)). Those opcodes are [`OP_RETURN_187`](./OP_RETURN_187.md) to [`OP_RETURN_254`](./OP_RETURN_254.md), and all render a script invalid if executed. This means that they essentially behave like [OP_RETURN](./OP_RETURN.md), but their use would make a script non-standard, and therefore a transaction that would include one of them would not be relayed by nodes by default.

--- a/opcodes/OP_RIGHT.md
+++ b/opcodes/OP_RIGHT.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_RIGHT` is a disabled opcode in the bitcoin scripting system.
+[`OP_RIGHT`](./OP_RIGHT.md) is a disabled opcode in the bitcoin scripting system.
 
 ### Historical Context
-Initially, the `OP_RIGHT` opcode was designed to retain only the rightmost N bytes of a string. During its operation, it would pop two items from the stack: the original string and a byte count. Subsequently, it would push back onto the stack the rightmost bytes of the string, determined by the byte count.
+Initially, the [`OP_RIGHT`](./OP_RIGHT.md) opcode was designed to retain only the rightmost N bytes of a string. During its operation, it would pop two items from the stack: the original string and a byte count. Subsequently, it would push back onto the stack the rightmost bytes of the string, determined by the byte count.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_RIGHT` (along with several other string manipulation opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_RIGHT`](./OP_RIGHT.md) (along with several other string manipulation opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_RIGHT` is disabled, the presence of this opcode in any script will immediately deem the transaction invalid, irrespective of its context.
+Because [`OP_RIGHT`](./OP_RIGHT.md) is disabled, the presence of this opcode in any script will immediately deem the transaction invalid, irrespective of its context.

--- a/opcodes/OP_RSHIFT.md
+++ b/opcodes/OP_RSHIFT.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_RSHIFT` is a disabled opcode in the Bitcoin scripting system.
+[`OP_RSHIFT`](./OP_RSHIFT.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-`OP_RSHIFT` was designed to perform bitwise right shift operations. This operation would shift the bits of the top stack item to the right by the number of positions specified by the second-to-top stack item.
+[`OP_RSHIFT`](./OP_RSHIFT.md) was designed to perform bitwise right shift operations. This operation would shift the bits of the top stack item to the right by the number of positions specified by the second-to-top stack item.
 
-Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, `OP_RSHIFT` (along with several other opcodes) was disabled early in bitcoin's development.
+Due to concerns about potential vulnerabilities and the desire to simplify the scripting language, [`OP_RSHIFT`](./OP_RSHIFT.md) (along with several other opcodes) was disabled early in bitcoin's development.
 
 ### Operation
-Because `OP_RSHIFT` is disabled, any script that contains it will render the transaction invalid regardless of context.
+Because [`OP_RSHIFT`](./OP_RSHIFT.md) is disabled, any script that contains it will render the transaction invalid regardless of context.

--- a/opcodes/OP_SUBSTR.md
+++ b/opcodes/OP_SUBSTR.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_SUBSTR` is a disabled opcode in the Bitcoin scripting system.
+[`OP_SUBSTR`](./OP_SUBSTR.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Historical Context
-In the original design of Bitcoin's scripting language, `OP_SUBSTR` was intended to extract a substring from a string. It would pop three items from the stack: the original string, a start position, and a length. It would then push the substring (starting at the given position and with the specified length) back onto the stack.
+In the original design of Bitcoin's scripting language, [`OP_SUBSTR`](./OP_SUBSTR.md) was intended to extract a substring from a string. It would pop three items from the stack: the original string, a start position, and a length. It would then push the substring (starting at the given position and with the specified length) back onto the stack.
 
 However, concerns about potential vulnerabilities and the complexity it would introduce to the scripting system led to its deactivation.
 
 ### Operation
-Because `OP_SUBSTR` is disabled, any script that contains it will cause the transaction to be invalid regardless of context.
+Because [`OP_SUBSTR`](./OP_SUBSTR.md) is disabled, any script that contains it will cause the transaction to be invalid regardless of context.

--- a/opcodes/OP_TOALTSTACK.md
+++ b/opcodes/OP_TOALTSTACK.md
@@ -5,7 +5,7 @@
 **Short description:** Move the top item from the main stack to the alternate stack.
 :::
 
-`OP_TOALTSTACK` is used to manipulate stack items between the main stack and an alternate stack.
+[`OP_TOALTSTACK`](./OP_TOALTSTACK.md) is used to manipulate stack items between the main stack and an alternate stack.
 
 :::warning
 This page is not well developed. If you think you can contribute to this page, please consider helping us out by [opening a pull request on the repo](https://github.com/thunderbiscuit/opcode-explained)!
@@ -18,13 +18,13 @@ This page is not well developed. If you think you can contribute to this page, p
 The [alternate stack](#) is a secondary stack that scripts can use to store data temporarily. It operates independently of the main stack, allowing for more complex script operations.
 
 ### Use Cases
-- **Temporary Storage:** Scripts can use `OP_TOALTSTACK` to temporarily store data that might be needed later in the script execution. This helps in organizing data and maintaining a clear main stack.
-- **Complex Script Logic:** In scripts that require intricate logic and multiple steps, `OP_TOALTSTACK` allows for better management of stack items and cleaner script execution.
+- **Temporary Storage:** Scripts can use [`OP_TOALTSTACK`](./OP_TOALTSTACK.md) to temporarily store data that might be needed later in the script execution. This helps in organizing data and maintaining a clear main stack.
+- **Complex Script Logic:** In scripts that require intricate logic and multiple steps, [`OP_TOALTSTACK`](./OP_TOALTSTACK.md) allows for better management of stack items and cleaner script execution.
 
 
 ### Notes
 - The alternate stack is not visible in script execution unless accessed explicitly.
-- `OP_TOALTSTACK` is often used in conjunction with [`OP_FROMALTSTACK`](./OP_FROMALTSTACK.md) to move items back to the main stack when needed.
+- [`OP_TOALTSTACK`](./OP_TOALTSTACK.md) is often used in conjunction with [`OP_FROMALTSTACK`](./OP_FROMALTSTACK.md) to move items back to the main stack when needed.
 
 ## Examples
 ### Example 1

--- a/opcodes/OP_VER.md
+++ b/opcodes/OP_VER.md
@@ -5,4 +5,4 @@
 **Short description:** Fail the script immediately.
 :::
 
-`OP_VER` fails the script immediately, but it must be executed (it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).
+[`OP_VER`](./OP_VER.md) fails the script immediately, but it must be executed (it does not render a script invalid if it is in a branch of an if/else statement that doesn't get executed). It is a synonym for [OP_RETURN](./OP_RETURN.md).

--- a/opcodes/OP_VERIF.md
+++ b/opcodes/OP_VERIF.md
@@ -5,7 +5,7 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_VERIF` is a disabled opcode in the Bitcoin scripting system.
+[`OP_VERIF`](./OP_VERIF.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Operation
 Because this opcode is disabled, any script that contains it will cause the transaction to be invalid regardless of context.

--- a/opcodes/OP_VERIFY.md
+++ b/opcodes/OP_VERIFY.md
@@ -5,14 +5,14 @@
 **Short description:** Checks the top stack value. If it's 0 or an empty string, the script fails; otherwise, it continues and the value is popped.
 :::
 
-`OP_VERIFY` is an opcode that allows for quick validation of conditions without explicitly ending the script. It's used to ensure certain requirements are met.
+[`OP_VERIFY`](./OP_VERIFY.md) is an opcode that allows for quick validation of conditions without explicitly ending the script. It's used to ensure certain requirements are met.
 
 ### Operation
 1. Pop the top stack value.
 2. If the value is `0` or an empty string, the script immediately fails and the transaction is considered invalid.
 3. If the value is non-zero, continue executing the script, with the item now removed from the stack.
 
-The primary use of `OP_VERIFY` is to verify that a certain condition holds without having to use conditional opcodes. If the condition does not hold, the script will terminate at the `OP_VERIFY` step.
+The primary use of [`OP_VERIFY`](./OP_VERIFY.md) is to verify that a certain condition holds without having to use conditional opcodes. If the condition does not hold, the script will terminate at the [`OP_VERIFY`](./OP_VERIFY.md) step.
 
 ## Notes
 - The opcode can be thought of as a shorthand for `OP_IF OP_DROP OP_ELSE OP_RETURN OP_ENDIF`.

--- a/opcodes/OP_VERNOTIF.md
+++ b/opcodes/OP_VERNOTIF.md
@@ -5,7 +5,7 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_VERNOTIF` is a disabled opcode in the Bitcoin scripting system.
+[`OP_VERNOTIF`](./OP_VERNOTIF.md) is a disabled opcode in the Bitcoin scripting system.
 
 ### Operation
 Because this opcode is disabled, any script that contains it will cause the transaction to be invalid regardless of context.

--- a/opcodes/OP_XOR.md
+++ b/opcodes/OP_XOR.md
@@ -5,12 +5,12 @@
 **Short description:** Fail the script unconditionally, does not even need to be executed.
 :::
 
-`OP_XOR` is a disabled opcode in the bitcoin scripting system.
+[`OP_XOR`](./OP_XOR.md) is a disabled opcode in the bitcoin scripting system.
 
 ### Historical Context
-Originally designed for Bitcoin's script, the `OP_XOR` opcode was intended to carry out a bitwise XOR (exclusive or) operation on the top two items on the stack. This operation would take two numbers and produce a new number wherein each bit is the result of the logical XOR between the corresponding bits in the input numbers.
+Originally designed for Bitcoin's script, the [`OP_XOR`](./OP_XOR.md) opcode was intended to carry out a bitwise XOR (exclusive or) operation on the top two items on the stack. This operation would take two numbers and produce a new number wherein each bit is the result of the logical XOR between the corresponding bits in the input numbers.
 
-However, as part of a broader effort to reduce potential vulnerabilities and to simplify bitcoin's scripting language, `OP_XOR` was disabled early in bitcoin's history along with several other opcodes.
+However, as part of a broader effort to reduce potential vulnerabilities and to simplify bitcoin's scripting language, [`OP_XOR`](./OP_XOR.md) was disabled early in bitcoin's history along with several other opcodes.
 
 ### Operation
-Due to its disabled status, any script containing the `OP_XOR` opcode will cause the transaction to be invalidated, regardless of any other conditions or script context.
+Due to its disabled status, any script containing the [`OP_XOR`](./OP_XOR.md) opcode will cause the transaction to be invalidated, regardless of any other conditions or script context.


### PR DESCRIPTION
This PR makes all `code references` to opcodes in the opcode pages hyper links to the referenced opcode, including links to the current page.

I found this to be mostly supported already, so I just did a global find/replace to apply the pattern everywhere, where applicable. There were a few exceptions that didn't work, like some of the opcode aliases.

I guess I should have asked if the maintainers of the project want this kind of change, but anyway, here it is :) 