### PR TITLE
add OP_SIZE

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -145,7 +145,7 @@ export default {
         { text: "<code>127 | OP_SUBSTR</code>", link: "/opcodes/OP_SUBSTR.md" },
         { text: "<code>128 | OP_LEFT</code>", link: "/opcodes/OP_LEFT.md" },
         { text: "<code>129 | OP_RIGHT</code>", link: "/opcodes/OP_RIGHT.md" },
-        { text: "<code>130 | 🚧 OP_SIZE</code>", link: "/opcodes/WIP.md" },
+        { text: "<code>130 | OP_SIZE</code>", link: "/opcodes/OP_SIZE.md" },
         { text: "<code>131 | OP_INVERT</code>", link: "/opcodes/OP_INVERT.md" },
         { text: "<code>132 | OP_AND</code>", link: "/opcodes/OP_AND.md" },
         { text: "<code>133 | OP_OR</code>", link: "/opcodes/OP_OR.md" },

--- a/opcodes/OP_SIZE.md
+++ b/opcodes/OP_SIZE.md
@@ -1,0 +1,53 @@
+# OP_SIZE
+:::info
+**Opcode number:** 130  
+**Byte representation:** `0x82`  
+**Short Description:** Push the length of the top stack item in bytes onto the stack
+:::
+
+The [`OP_SIZE`](./OP_SIZE.md) opcode pushes the length of the top stack item in bytes onto the stack.
+
+## NOTES 
+- The stack item that was previously the top stack item is unaffected and simply becomes the second item on the stack following the output from [`OP_SIZE`](./OP_SIZE.md)
+- If the stack is empty the script fails.
+
+## Examples
+### Example 1
+Measuring the length of 0 as an empty byte array results in a length of 0:
+```shell
+# ASM script
+OP_0 OP_SIZE
+
+# Raw script
+0082
+
+# Final stack
+0
+0
+```
+### Example 2
+Any opcode that returns true pushes to the stack a 1 which is a single byte:
+```shell
+# ASM script
+OP_1 OP_2 OP_ADD OP_3 OP_EQUAL OP_SIZE
+
+# Raw script
+515293538782
+
+# Final stack
+1
+1
+```
+### Example 3
+OP_SIZE measures the length in bytes and since [`OP_PUSHBYTES_3`](./OP_PUSHBYTES_3.md) always pushes 3 bytes the length will be 3: 
+```shell
+# ASM script
+OP_PUSHBYTES_3 a4b5c6 OP_SIZE
+
+# Raw script
+03a4b5c682
+
+# Final stack
+3
+a4b5c6
+```


### PR DESCRIPTION
~~I do have a question about this documentation as it seems unclear to me.~~

~~In the bitcoin.it wiki https://en.bitcoin.it/wiki/Script#Splice it says that OP_SIZE measures the string length of the top stack item but upon looking at the source code https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L872 it appears to me to be measured in the native bytes of the bitcoin stack~~

~~Is this correct, is it measuring the bytes or the string length?~~

According to some other devs I asked It is measuring bytes.

[Preview](https://deploy-preview-19--timely-chimera-eba3bb.netlify.app/opcodes/OP_SIZE.html)