### PR TITLE
doc: update OP_RETURN size notes

### DIFF
--- a/opcodes/OP_RETURN.md
+++ b/opcodes/OP_RETURN.md
@@ -12,8 +12,7 @@
 
 ## Notes
 - [`OP_RETURN`](./OP_RETURN.md) is commonly followed by a pushdata operation that determines the length of the data to be embedded, and then the data itself.
-- The maximum size of the data push is 80 bytes.
-- This means that `OP_RETURN` can be at most 83 bytes: 1 byte for the opcode, 1-2 bytes for the data push, and 80 bytes of data.
+- The maximum size of the data push is limited to the block weight limit in case the transaction weight limit standarness rule of 400000 WU is bypassed.
 - [`OP_RETURN`](./OP_RETURN.md) outputs are used for various purposes, from proving the existence of a particular piece of data at a certain point in time to more complex protocols built on top of bitcoin.
 - Historically, there were debates around the use of [`OP_RETURN`](./OP_RETURN.md) because embedding data into the bitcoin blockchain adds to its size without directly supporting the transfer of bitcoin.
 


### PR DESCRIPTION
The maximum size notes were a bit "wrong" or not well defined as it was limited by policy rules and op_return > 80bytes data were valid even with the standarness rule...

This PR updates the limits to consensus rules and defines the policy rules that affects OP_RETURN after core v30.